### PR TITLE
Apply overlays after all images have loaded

### DIFF
--- a/mrbeastify.js
+++ b/mrbeastify.js
@@ -59,6 +59,9 @@ function checkImageAmountInDirectory() { // Checks for all images in the images 
           imageIndex++;
           checkImageExistence();
         }
+      })
+      .catch(() => {
+        applyOverlayToThumbnails();
       });
   }
   checkImageExistence();
@@ -71,8 +74,5 @@ function getRandomImageFromDirectory() {
 }
 
 checkImageAmountInDirectory()
-setInterval(function () {
-  applyOverlayToThumbnails();
-}, 100);
 
 console.log("MrBeastify Loaded Successfully");


### PR DESCRIPTION
The current behavior starts applying overlays after a short timeout, irrespective of whether all the images have loaded or not. For slow connections this means that all the overlays may end up being the same one or two images repeated. 

This commit ensures the overlays only start applying once we've stopped fetching image URLs.