### PR TITLE
Fix not applying overlay when refreshing homepage by other means (clicking youtube logo)

### DIFF
--- a/mrbeastify.js
+++ b/mrbeastify.js
@@ -30,7 +30,7 @@ function applyOverlayToThumbnails() {
   // Query all YouTube video thumbnails on the page that haven't been processed yet
   // ignores shorts thumbnails and thumbnails that already have a mr beast on them
   const elementQuery =
-    "ytd-thumbnail:not(.ytd-video-preview, .ytd-rich-grid-slim-media) a > yt-image > img.yt-core-image:not(.processed):not(.yt-core-attributed-string__image-element)";
+    "ytd-thumbnail:not(.ytd-video-preview, .ytd-rich-grid-slim-media) > a > yt-image:not(:has(img.mr-beast)) > img.yt-core-image:not(.yt-core-attributed-string__image-element)";
   const thumbnailElements = document.querySelectorAll(elementQuery);
 
   // Apply overlay to each thumbnail

--- a/mrbeastify.js
+++ b/mrbeastify.js
@@ -30,7 +30,7 @@ function applyOverlayToThumbnails() {
   // Query all YouTube video thumbnails on the page that haven't been processed yet
   // ignores shorts thumbnails and thumbnails that already have a mr beast on them
   const elementQuery =
-    "ytd-thumbnail:not(.ytd-video-preview, .ytd-rich-grid-slim-media) > a > yt-image:not(:has(img.mr-beast)) > img.yt-core-image:not(.yt-core-attributed-string__image-element)";
+    "ytd-thumbnail:not(.ytd-video-preview, .ytd-rich-grid-slim-media) > a > yt-image > img.yt-core-image:only-child:not(.yt-core-attributed-string__image-element)";
   const thumbnailElements = document.querySelectorAll(elementQuery);
 
   // Apply overlay to each thumbnail
@@ -74,13 +74,3 @@ function getRandomImageFromDirectory() {
   const randomIndex = Math.floor(Math.random() * images.length);
   return images[randomIndex];
 }
-
-// Checks for all images in the images folder instead of using a preset array, making the extension infinitely scalable
-let imageIndex = 1;
-checkImageExistence(imageIndex);
-
-setInterval(function () {
-  applyOverlayToThumbnails();
-}, 500);
-
-console.log("MrBeastify Loaded Successfully");

--- a/mrbeastify.js
+++ b/mrbeastify.js
@@ -5,6 +5,7 @@ const images = [];
 function applyOverlay(thumbnailElement, overlayImageUrl, flip) {
   // Create a new img element for the overlay
   const overlayImage = document.createElement("img");
+  overlayImage.classList = "mr-beast";
   overlayImage.src = overlayImageUrl;
   overlayImage.style.position = "absolute";
   overlayImage.style.top = "0";
@@ -22,13 +23,12 @@ function applyOverlay(thumbnailElement, overlayImageUrl, flip) {
 
   // Append the overlay to the parent of the thumbnail
   thumbnailElement.parentElement.appendChild(overlayImage);
-  thumbnailElement.classList.add("processed");
 }
 
 // Looks for all thumbnails and applies overlay
 function applyOverlayToThumbnails() {
   // Query all YouTube video thumbnails on the page that haven't been processed yet
-  // (ignores shorts thumbnails)
+  // ignores shorts thumbnails and thumbnails that already have a mr beast on them
   const elementQuery =
     "ytd-thumbnail:not(.ytd-video-preview, .ytd-rich-grid-slim-media) a > yt-image > img.yt-core-image:not(.processed):not(.yt-core-attributed-string__image-element)";
   const thumbnailElements = document.querySelectorAll(elementQuery);
@@ -47,27 +47,40 @@ function applyOverlayToThumbnails() {
   });
 }
 
-function checkImageExistence(index = 1) { // Checks for all images in the images folder instead of using a preset array, making the extension infinitely scalable
+function checkImageExistence(index = 1) {
+  // Checks for all images in the images folder instead of using a preset array, making the extension infinitely scalable
   const testedURL = chrome.runtime.getURL(`${imagesPath}${index}.png`);
-  fetch(testedURL).then(response => {
-    if (response.status === 200) {
-      // Image exists, add it to the images array
-      images.push(testedURL);
-      // Check the next image in the directory
-      checkImageExistence(index + 1);
-    }
-  }).catch(error => {
-    setInterval(applyOverlayToThumbnails, 100);
-    console.log("MrBeastify Loaded Successfully, " + (index - 1) + " images detected.");
-  });
+  fetch(testedURL)
+    .then((response) => {
+      if (response.status === 200) {
+        // Image exists, add it to the images array
+        images.push(testedURL);
+        // Check the next image in the directory
+        checkImageExistence(index + 1);
+      }
+    })
+    .catch((error) => {
+      setInterval(applyOverlayToThumbnails, 100);
+      console.log(
+        "MrBeastify Loaded Successfully, " + (index - 1) + " images detected."
+      );
+    });
 }
 
-
 checkImageExistence();
-
 
 // Get a random image URL from a directory
 function getRandomImageFromDirectory() {
   const randomIndex = Math.floor(Math.random() * images.length);
   return images[randomIndex];
 }
+
+// Checks for all images in the images folder instead of using a preset array, making the extension infinitely scalable
+let imageIndex = 1;
+checkImageExistence(imageIndex);
+
+setInterval(function () {
+  applyOverlayToThumbnails();
+}, 500);
+
+console.log("MrBeastify Loaded Successfully");


### PR DESCRIPTION
resolves #2

fix not applying overlay when clicked on youtube logo or redirecting to the home page from another page

this is done by not checking for `.processed` anymore, but instead checking the `ytd-thumbnail` element for the MrBeast overlay: `yt-image:not(:has(img.mr-beast))`

if no overlay, apply.

i think interval should also be 500ms (or longer) instead, but can be changed on your request

before

https://github.com/MagicJinn/MrBeastify-Youtube/assets/49902829/80a4c634-4530-4280-b777-3ad48f0204df

after

https://github.com/MagicJinn/MrBeastify-Youtube/assets/49902829/8c9b81a3-ab47-46f1-9ccb-f899eb748037

