### PR TITLE
Change for not repeating images too closely

### DIFF
--- a/mrbeastify.js
+++ b/mrbeastify.js
@@ -65,9 +65,6 @@ function getRandomImageFromDirectory() {
   // and pushes the current index.  
   last_indexes.shift()
   last_indexes.push(randomIndex)
-  
-  console.log(last_indexes)
-
 
   return getImageURL(randomIndex);
 }

--- a/mrbeastify.js
+++ b/mrbeastify.js
@@ -48,7 +48,7 @@ function getImageURL(index) {
 }
 
 // Defines the N size of last images that will not be repeated.
-const size_of_non_repeat = 10
+const size_of_non_repeat = 8
 // List of the index of the last N selected images.
 const last_indexes = Array(size_of_non_repeat)
 

--- a/mrbeastify.js
+++ b/mrbeastify.js
@@ -47,9 +47,27 @@ function getImageURL(index) {
   return chrome.runtime.getURL(`${imagesPath}${index}.png`);
 }
 
+// Defines the N size of last images that will not be repeated.
+const size_of_non_repeat = 10
+// List of the index of the last N selected images.
+const last_indexes = Array(size_of_non_repeat)
+
 // Get a random image URL from a directory
 function getRandomImageFromDirectory() {
-  const randomIndex = Math.floor(Math.random() * highestImageIndex) + 1;
+  let randomIndex = -1
+
+  // It selects a random index until it finds one that is not repeated
+  while (last_indexes.includes(randomIndex) || randomIndex < 0) {
+    randomIndex = Math.floor(Math.random() * highestImageIndex) + 1;
+  }
+
+  // When it finds the non repeating index, it eliminates the oldest value,
+  // and pushes the current index.  
+  last_indexes.shift()
+  last_indexes.push(randomIndex)
+  
+  console.log(last_indexes)
+
 
   return getImageURL(randomIndex);
 }


### PR DESCRIPTION
In the line 51 it specifies how many indexes it remembers, so it doesn't repeat those. I thought 10 would be enough to not see repeated in the home page of youtube.

Resolves #28 